### PR TITLE
Building and testing using Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: objective-c
+osx_image: xcode61
+script:
+  - xctool -scheme MacPass build test CODE_SIGN_IDENTITY=""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #MacPass
 
-[![Build Status](https://travis-ci.org/tanob/MacPass.svg)](https://travis-ci.org/tanob/MacPass)
+[![Build Status](https://travis-ci.org/mstarke/MacPass.svg)](https://travis-ci.org/mstarke/MacPass)
 
 There are a lot of iOS KeePass tools around but a distinct lack of a good OS X version.
 KeePass can be used via Mono on OS X but lacks vital functionality and feels sluggish.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #MacPass
 
+[![Build Status](https://travis-ci.org/tanob/MacPass.svg)](https://travis-ci.org/tanob/MacPass)
+
 There are a lot of iOS KeePass tools around but a distinct lack of a good OS X version.
 KeePass can be used via Mono on OS X but lacks vital functionality and feels sluggish.
 


### PR DESCRIPTION
This PR adds support to build and test MacPass using Travis CI. I've also added a build status image in the README.

You'll see that the build is currently broken, that's because there are some broken tests.

Maybe after fixing the tests we could configure Travis CI to upload the app to [Github Releases](http://docs.travis-ci.com/user/deployment/releases/)? I think we'll also need to fix the signing part if we want to distribute the generated app.
