### PR TITLE
Corrected the German translation

### DIFF
--- a/MacPass/de.lproj/MainMenu.strings
+++ b/MacPass/de.lproj/MainMenu.strings
@@ -150,13 +150,13 @@
 "1261.title" = "Verschließen";
 
 /* Class = "NSMenuItem"; title = "Focus Entries"; ObjectID = "2VP-vB-IeX"; */
-"2VP-vB-IeX.title" = "Einträge fokusieren";
+"2VP-vB-IeX.title" = "Einträge fokussieren";
 
 /* Class = "NSMenuItem"; title = "Focus Groups"; ObjectID = "HxM-dV-LIH"; */
-"HxM-dV-LIH.title" = "Gruppen fokusieren";
+"HxM-dV-LIH.title" = "Gruppen fokussieren";
 
 /* Class = "NSMenuItem"; title = "Focus Inspector"; ObjectID = "Zje-Me-5c8"; */
-"Zje-Me-5c8.title" = "Inspektor fokusieren";
+"Zje-Me-5c8.title" = "Inspektor fokussieren";
 
 /* Class = "NSMenuItem"; title = "Quicklook"; ObjectID = "aVO-9F-Lwc"; */
 "aVO-9F-Lwc.title" = "Quicklook";


### PR DESCRIPTION
The word `fokussieren` had a missing s.