### PR TITLE
Fix for https://github.com/mstarke/MacPass/issues/386

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you want to live dangerously and want to take a look at the master:
     git clone https://github.com/mstarke/MacPass
     cd MacPass
     git submodule init
-    git submodule update
+    git submodule update --init --recursive
 
 After that you can build and run in Xcode. If you run into signing issues take a look at [Issue #92](https://github.com/mstarke/MacPass/issues/92)
 


### PR DESCRIPTION
Change to documentation:
Recursive init and update is required to correctly initialize second order dependencies (DDXMLDocument.h in KeePassKit/KissXML was not found).