### PR TITLE
Add xcode install command to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ If you want to live dangerously and want to take a look at the master:
 
     git clone https://github.com/mstarke/MacPass
     cd MacPass
-    git submodule init
     git submodule update --init --recursive
 
 After that you can build and run in Xcode. If you run into signing issues take a look at [Issue #92](https://github.com/mstarke/MacPass/issues/92)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ If you want to live dangerously and want to take a look at the master:
     cd MacPass
     git submodule update --init --recursive
 
-After that you can build and run in Xcode. If you run into signing issues take a look at [Issue #92](https://github.com/mstarke/MacPass/issues/92)
+After that you can build and run in Xcode. The following command will build and make the application available through Spotlight.
+If you run into signing issues take a look at [Issue #92](https://github.com/mstarke/MacPass/issues/92)
+
+    xcodebuild -scheme MacPass -target MacPass -configuration Release
 
 There have been some changes in the submodule urls. Please consider re-syncing and initalizing all submodules.
 


### PR DESCRIPTION
I've never built anything with Xcode, but wanted to run the master branch version of MacPass to be able to use MacPassHTTP. Unfortunately the exact steps for doing this weren't specified and a simple `xcodebuild` failed. So after some searching and trial and error I found a command that did exactly what I needed and added it to *README* for easy reference for others in a similar situation.

Please let me know if there's a better/shorter command for reaching the same result.