### PR TITLE
Enable Travis CI with carthage usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+osx_image: xcode7.2
+language: objective-c
+before_install:
+- brew update
+- brew outdated xctool || brew upgrade xctool
+- brew install carthage
+script: ci/build
+notifications:
+  email: false

--- a/ci/build
+++ b/ci/build
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+git submodule update --init --recursive
+carthage bootstrap --platform Mac
+xcodebuild
+xcodebuild -scheme MacPass -target MacPass -configuration Release


### PR DESCRIPTION
Hey, 

yet another Travis PR. This time it uses the carthage dep manager / or rather just the build process as given in your README.

You may need to add a GitHub API Key into the Travis secure environment variables to bypass possible issues arising from the GitHub API limit being hit by Travis.
Also, Travis appears to offer an integration for various artifact providers, such as the GitHub releases, S3 or similar things.
