### PR TITLE
Updated German translation

### DIFF
--- a/MacPass/de.lproj/MainMenu.strings
+++ b/MacPass/de.lproj/MainMenu.strings
@@ -135,7 +135,7 @@
 "1200.title" = "Passwortgenerator anzeigen";
 
 /* Class = "NSMenuItem"; title = "Change Master Password…"; ObjectID = "1203"; */
-"1203.title" = "Datenbankpassword ändern …";
+"1203.title" = "Datenbankpasswort ändern …";
 
 /* Class = "NSMenuItem"; title = "Database Settings…"; ObjectID = "1231"; */
 "1231.title" = "Datenbankeinstellungen …";


### PR DESCRIPTION
The German equivalent for "password" is "Passwort".
All other occurrences are with "Passwor**t**", too.

Cheers,
Tim

PS: MacPass rocks :rocket: 