### PR TITLE
Made the password length field editable in password generator

### DIFF
--- a/MacPass/Base.lproj/PasswordCreatorView.xib
+++ b/MacPass/Base.lproj/PasswordCreatorView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9059"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
         <capability name="box content view" minToolsVersion="7.0"/>
     </dependencies>
     <objects>
@@ -33,46 +33,44 @@
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="148">
                     <rect key="frame" x="18" y="253" width="66" height="17"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Password:" id="149">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="152">
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="152">
                     <rect key="frame" x="90" y="247" width="200" height="24"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="621"/>
                     </constraints>
-                    <animations/>
                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="153" customClass="HNHUIRoundedTextFieldCell">
                         <font key="font" size="13" name="Menlo-Regular"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <slider verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="173">
+                <slider verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="173">
                     <rect key="frame" x="88" y="220" width="204" height="21"/>
-                    <animations/>
                     <sliderCell key="cell" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="174"/>
                 </slider>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="178">
                     <rect key="frame" x="18" y="222" width="66" height="17"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Length:" id="179">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="182">
+                <textField verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="182">
                     <rect key="frame" x="298" y="219" width="28" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="28" id="eVc-Kg-bCi"/>
                     </constraints>
-                    <animations/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="183">
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="183">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="CNP-dv-vhg">
+                            <real key="minimum" value="0.0"/>
+                        </numberFormatter>
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -86,7 +84,6 @@
                         <subviews>
                             <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="411">
                                 <rect key="frame" x="18" y="19" width="274" height="22"/>
-                                <animations/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="412" customClass="HNHUIRoundedTextFieldCell">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -95,7 +92,6 @@
                             </textField>
                             <button verticalHuggingPriority="750" misplaced="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="452">
                                 <rect key="frame" x="18" y="49" width="37" height="19"/>
-                                <animations/>
                                 <buttonCell key="cell" type="roundRect" title="A-Z" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="453">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                     <font key="font" metaFont="cellTitle"/>
@@ -106,7 +102,6 @@
                             </button>
                             <button verticalHuggingPriority="750" misplaced="YES" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="456">
                                 <rect key="frame" x="63" y="49" width="35" height="19"/>
-                                <animations/>
                                 <buttonCell key="cell" type="roundRect" title="a-z" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="457">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                     <font key="font" metaFont="cellTitle"/>
@@ -117,7 +112,6 @@
                             </button>
                             <button verticalHuggingPriority="750" misplaced="YES" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="460">
                                 <rect key="frame" x="106" y="49" width="37" height="19"/>
-                                <animations/>
                                 <buttonCell key="cell" type="roundRect" title="0-9" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="461">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                     <font key="font" metaFont="cellTitle"/>
@@ -128,7 +122,6 @@
                             </button>
                             <button verticalHuggingPriority="750" misplaced="YES" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="464">
                                 <rect key="frame" x="151" y="49" width="31" height="19"/>
-                                <animations/>
                                 <buttonCell key="cell" type="roundRect" title="#!?" bezelStyle="roundedRect" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="465">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                     <font key="font" metaFont="cellTitle"/>
@@ -139,14 +132,12 @@
                             </button>
                             <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="468">
                                 <rect key="frame" x="190" y="49" width="59" height="19"/>
-                                <animations/>
                                 <buttonCell key="cell" type="roundRect" title="Custom" bezelStyle="roundedRect" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="469">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES" changeBackground="YES" changeGray="YES"/>
                                     <font key="font" metaFont="cellTitle"/>
                                 </buttonCell>
                             </button>
                         </subviews>
-                        <animations/>
                     </view>
                     <constraints>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="468" secondAttribute="trailing" constant="16" id="1AP-Bk-63Z"/>
@@ -165,13 +156,11 @@
                         <constraint firstItem="411" firstAttribute="leading" secondItem="332" secondAttribute="leading" constant="16" id="iWf-dT-uLW"/>
                         <constraint firstItem="452" firstAttribute="top" secondItem="332" secondAttribute="top" constant="25" id="jTr-D4-0Uf"/>
                     </constraints>
-                    <animations/>
                     <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                     <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                 </box>
                 <button verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="494">
                     <rect key="frame" x="227" y="18" width="99" height="25"/>
-                    <animations/>
                     <buttonCell key="cell" type="roundTextured" title="Use Password" bezelStyle="texturedRounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="495">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -182,15 +171,13 @@
                 </button>
                 <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="500">
                     <rect key="frame" x="18" y="68" width="209" height="18"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Copy password to pasteboard" bezelStyle="regularSquare" imagePosition="left" inset="2" id="501">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                 </button>
-                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="509">
+                <button verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="509">
                     <rect key="frame" x="298" y="247" width="28" height="25"/>
-                    <animations/>
                     <buttonCell key="cell" type="roundTextured" bezelStyle="texturedRounded" image="NSRefreshTemplate" imagePosition="only" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="510">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -201,7 +188,6 @@
                 </button>
                 <button verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="613">
                     <rect key="frame" x="163" y="18" width="56" height="25"/>
-                    <animations/>
                     <buttonCell key="cell" type="roundTextured" title="Cancel" bezelStyle="texturedRounded" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="614">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -212,12 +198,10 @@
                 </button>
                 <levelIndicator verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="635">
                     <rect key="frame" x="90" y="190" width="165" height="16"/>
-                    <animations/>
                     <levelIndicatorCell key="cell" alignment="left" doubleValue="10" maxValue="90" warningValue="55" criticalValue="30" levelIndicatorStyle="continuousCapacity" id="636" customClass="HNHUILevelIndicatorCell"/>
                 </levelIndicator>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="646">
                     <rect key="frame" x="18" y="190" width="66" height="17"/>
-                    <animations/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Entropy:" id="647">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -226,7 +210,6 @@
                 </textField>
                 <textField verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="652">
                     <rect key="frame" x="261" y="190" width="67" height="17"/>
-                    <animations/>
                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="25000 bit" id="653">
                         <numberFormatter key="formatter" formatterBehavior="custom10_4" positiveFormat="# bit" negativeFormat="# bit" usesGroupingSeparator="NO" paddingCharacter="*" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="309" decimalSeparator="," groupingSeparator="." currencyDecimalSeparator="," plusSign="+" minusSign="-" notANumberSymbol="NaN" perMillSymbol="‰" percentSymbol="%" exponentSymbol="E" positivePrefix="" positiveSuffix=" bit" negativePrefix="-" negativeSuffix=" bit" id="681"/>
                         <font key="font" metaFont="system"/>
@@ -236,7 +219,6 @@
                 </textField>
                 <button verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yil-UB-jtO">
                     <rect key="frame" x="20" y="18" width="83" height="25"/>
-                    <animations/>
                     <buttonCell key="cell" type="roundTextured" title="Set Default" bezelStyle="texturedRounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Wvs-Md-Ob8">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -247,7 +229,6 @@
                 </button>
                 <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4yb-SC-vau">
                     <rect key="frame" x="18" y="48" width="237" height="18"/>
-                    <animations/>
                     <buttonCell key="cell" type="check" title="Use default only for selected entry" bezelStyle="regularSquare" imagePosition="left" inset="2" id="cfZ-5F-Nge">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -298,7 +279,6 @@
                 <constraint firstItem="178" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="20" symbolic="YES" id="pAc-di-F68"/>
                 <constraint firstItem="500" firstAttribute="leading" secondItem="4yb-SC-vau" secondAttribute="leading" id="xv1-5v-Ljh"/>
             </constraints>
-            <animations/>
             <point key="canvasLocation" x="140" y="81.5"/>
         </customView>
     </objects>

--- a/MacPass/MPEntryInspectorViewController.m
+++ b/MacPass/MPEntryInspectorViewController.m
@@ -299,6 +299,20 @@ static NSString *kMPContentBindingString3 = @"content.%@.%@.%@";
   [_activePopover showRelativeToRect:NSZeroRect ofView:view preferredEdge:edge];
 }
 
+- ( BOOL) popoverShouldClose: ( NSPopover*) popover {
+  /* See http://stackoverflow.com/a/34215887/353268
+   * PasswordCreator uses a NSNumberFormatter to validate the input.
+   * If the user types something that's not a number it will open a
+   * dialog, which would cause the popover to close and MacPass to crash.
+   *
+   * This stops the popover to close when the dialog is active.
+   */
+  if( ![[[[ popover contentViewController] view] window] makeFirstResponder: popover]) {
+    return NO;
+  }
+  return YES;
+}
+
 - (void)popoverDidClose:(NSNotification *)notification {
   /* We do not enable the button all the time, but it's working find this way */
   [self.generatePasswordButton setEnabled:YES];


### PR DESCRIPTION
This should implement the feature requested in #415.

Apologies for all the noise introduced by the new version of Xcode. I hope it's not causing troubles.

The change is quite simple. I just made the text field editable and added a number formatter to take care of input validation.
The only tricky part is the change I made to MPEntryInspectorViewController to prevent the popover to close if the input string is not valid.
Here there are some solution to the issue http://stackoverflow.com/questions/22211672/using-an-nsnumberformatter-in-an-nspopover I implemented the one that I though was the simplest and it's working perfectly fine. You might want to have a look at the other options and see if there is something you like more.