### PR TITLE
Fix entropy calculation

### DIFF
--- a/MacPass/NSString+MPPasswordCreation.m
+++ b/MacPass/NSString+MPPasswordCreation.m
@@ -115,7 +115,7 @@ static NSString *mergeWithoutDuplicates(NSString* baseCharacters, NSString* cust
                                                   customCharacters);
   }
   CGFloat alphabetCount = characters.length;
-  CGFloat passwordLegnth = self.length;
-  return passwordLegnth * ( log10(alphabetCount) / log10(2) );
+  CGFloat passwordLength = self.length;
+  return passwordLength * ( log10(alphabetCount) / log10(2) );
 }
 @end

--- a/MacPass/NSString+MPPasswordCreation.m
+++ b/MacPass/NSString+MPPasswordCreation.m
@@ -105,11 +105,16 @@ static NSString *mergeWithoutDuplicates(NSString* baseCharacters, NSString* cust
 }
 
 - (CGFloat)entropyWhithPossibleCharacterSet:(MPPasswordCharacterFlags)allowedCharacters orCustomCharacters:(NSString *)customCharacters {
-  CGFloat alphabetCount = customCharacters.length;
+  NSString *characters = nil;
   if(nil == customCharacters) {
-    NSString *stringSet = allowedCharactersString(allowedCharacters);
-    alphabetCount = stringSet.length;
+    characters = allowedCharactersString(allowedCharacters);
   }
+  else {
+    NSString *characters = mergeWithoutDuplicates(
+                                                  allowedCharactersString(allowedCharacters),
+                                                  customCharacters);
+  }
+  CGFloat alphabetCount = characters.length;
   CGFloat passwordLegnth = self.length;
   return passwordLegnth * ( log10(alphabetCount) / log10(2) );
 }


### PR DESCRIPTION
When custom characters was used only the custom string was used in calculation. Now the character sets are merged with any custom characters.