### PR TITLE
Add correct github page variables

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,9 @@ description: A KeePass client for OS X
 google_analytics: 
 show_downloads: true
 theme: jekyll-theme-cayman
-
+github:
+  zip_url: https://github.com/mstarke/MacPass/zipball/master
+  tar_url: https://github.com/mstarke/MacPass/tarball/master
+  
 gems:
   - jekyll-mentions


### PR DESCRIPTION
Setting correct github variables for zip and tar downloads to point to project (master) files instead of the gh-pages branch (see: https://github.com/pages-themes/midnight/issues/4). 

Closes #626