### PR TITLE
Fixed a typo in German translation

### DIFF
--- a/MacPass/de.lproj/Localizable.strings
+++ b/MacPass/de.lproj/Localizable.strings
@@ -194,7 +194,7 @@
 "CHANGE_PASSWORD_WITH_DOTS" = "Password ändern …";
 
 "WARNING_ON_SAVE_NO_PASSWORD_OR_KEY_SET" = "Weder Password noch Schlüsseldatei sind festgelegt!";
-"WARNING_ON_SAVE_NO_PASSWORD_OR_KEY_SET_SUGGESTION" = "Bitte vergeben Sie ein Password und/oder einen Schlüssel. Sofern Sie abbrechen, werden Ihre Änderugnen rückgängig gemacht und die Datei gesperrt.";
+"WARNING_ON_SAVE_NO_PASSWORD_OR_KEY_SET_SUGGESTION" = "Bitte vergeben Sie ein Password und/oder einen Schlüssel. Sofern Sie abbrechen, werden Ihre Änderungen rückgängig gemacht und die Datei gesperrt.";
 
 /* Message displayed when an open file was changed from another application */
 "FILE_CHANGED_BY_OTHERS_MESSAGE_TEXT" = "Die Datei wurde verändert!";


### PR DESCRIPTION
`Änderugnen` -> `Änderungen`
See http://www.duden.de/rechtschreibung/Aenderung