### PR TITLE
cd into MacPass prior to running carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ git clone https://github.com/mstarke/MacPass --recursive
 * Install [Carthage](https://github.com/Carthage/Carthage#installing-carthage)
 * Install all Dependencies
 ```bash
+cd MacPass
 carthage bootstrap --platform Mac
 ```
 After that you can build and run in Xcode. The following command will build and make the application available through Spotlight. If you run into signing issues take a look at [Issue #92](https://github.com/mstarke/MacPass/issues/92)


### PR DESCRIPTION
The command `carthage bootstrap --platform Mac` needs to be run from inside the MacPass project directory. This PR adds that missing line in the doc.

This is to avoid the following error:

```
*** No Cartfile.resolved found, updating dependencies
Failed to read file or folder at /Users/user/Cartfile: Error Domain=NSCocoaErrorDomain Code=260 "The file “Cartfile” couldn’t be opened because there is no such file." UserInfo={NSFilePath=/Users/user/Cartfile, NSUnderlyingError=0x7ff676546e30 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
```